### PR TITLE
fix: placelist color gap and translate-x-amount according to responsi…

### DIFF
--- a/src/components/PlaceList.tsx
+++ b/src/components/PlaceList.tsx
@@ -11,10 +11,16 @@ function PlaceList({}) {
                 <Link href={`/place/${data.name}`}>
                     <div key={`${idx}. ${data.place}`} className="relative cursor-pointer" onMouseOver={() => setIsHover(idx)} onMouseOut={() => setIsHover(100)}>
                         <img src="/img_example.jpg" className={`${isHover == idx ? `opacity-80` : `opacity-100`} transition duration-1000`} alt={`${data.place}`} />
-                        <a className={`${isHover == idx ? 'opacity-100 visible translate-x-6' : 'opacity-0'} transition duration-1000 text-lg font-[700] bottom-14 z-20 absolute`}>{data.place}</a>
-                        <div className={`${isHover == idx ? 'opacity-100 visible translate-x-6' : 'opacity-0'} transition duration-1000 absolute z-20 bottom-6 flex space-x-4`}>
+                        <a className={`${isHover == idx ? 'opacity-100 visible translate-x-3 lg:translate-x-6' : 'opacity-0'} transition duration-1000 text-lg font-[700] bottom-14 z-20 absolute`}>
+                            {data.place}
+                        </a>
+                        <div
+                            className={`${
+                                isHover == idx ? 'opacity-100 visible translate-x-3 lg:translate-x-6' : 'opacity-0'
+                            } transition duration-1000 absolute z-20 bottom-6 flex space-x-2 lg:space-x-3`}
+                        >
                             {data.colorList3.map((color, idx2) => (
-                                <div key={`${idx2} ${color}`} className="w-6 h-6 inline-flex" style={{ backgroundColor: `${color}`}}></div>
+                                <div key={`${idx2} ${color}`} className="w-6 h-6 inline-flex" style={{ backgroundColor: `${color}` }}></div>
                             ))}
                         </div>
                     </div>

--- a/src/pages/place/[name].tsx
+++ b/src/pages/place/[name].tsx
@@ -29,7 +29,7 @@ function Place() {
 
     return (
         <div>
-            <section className="w-full h-[calc(100vh-5vw-2.5rem)] flex items-center">
+            <section className="w-full h-[calc(100vh-5vw-2.5rem)] flex items-center justify-center">
                 <PalleteSlider colorList3={data.colorList3} colorList4={data.colorList4} colorList5={data.colorList5}></PalleteSlider>
             </section>
         </div>


### PR DESCRIPTION
**주요 변경사항**
1. 모바일뷰 `Placelist.tsx`에서 hover시에 화면폭을 넘어서 `translate-x`가 되는 것을 수정. (`lg`부터 원래 우리가 설계한대로 나타나도록)
2. 1번에 이어서 hover시에 나타나는 색상들의 간격들도 모바일뷰에 맞춰서 수정.
3. `[name].tsx`에서 전체적으로 팔레트를 화면 중앙에 오도록 수정.